### PR TITLE
Enable windows auth in tests via web.config.

### DIFF
--- a/test/TestSites/wwwroot/web.config
+++ b/test/TestSites/wwwroot/web.config
@@ -1,0 +1,8 @@
+<configuration>
+  <system.webServer>
+    <httpPlatform forwardWindowsAuthToken="true" />
+    <handlers>
+      <add name="httpplatformhandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+    </handlers>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
@davidfowl @muratg @victorhurdugaci 
Victor, this is one of the last blockers for the x-plat tests.