### PR TITLE
Lower integration test timeouts.

### DIFF
--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HelloWorldTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HelloWorldTest.cs
@@ -74,13 +74,17 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 {
                     var deploymentResult = deployer.Deploy();
                     var httpClientHandler = new HttpClientHandler();
-                    var httpClient = new HttpClient(httpClientHandler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
+                    var httpClient = new HttpClient(httpClientHandler)
+                    {
+                        BaseAddress = new Uri(deploymentResult.ApplicationBaseUri),
+                        Timeout = TimeSpan.FromSeconds(5),
+                    };
 
                     // Request to base address and check if various parts of the body are rendered & measure the cold startup time.
                     var response = await RetryHelper.RetryRequest(() =>
                     {
                         return httpClient.GetAsync(string.Empty);
-                    }, logger, deploymentResult.HostShutdownToken);
+                    }, logger, deploymentResult.HostShutdownToken, retryCount: 30);
 
                     var responseText = await response.Content.ReadAsStringAsync();
                     try

--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HttpsTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HttpsTest.cs
@@ -48,13 +48,17 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                     var deploymentResult = deployer.Deploy();
                     var handler = new WebRequestHandler();
                     handler.ServerCertificateValidationCallback = (a, b, c, d) => true;
-                    var httpClient = new HttpClient(handler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
+                    var httpClient = new HttpClient(handler)
+                    {
+                        BaseAddress = new Uri(deploymentResult.ApplicationBaseUri),
+                        Timeout = TimeSpan.FromSeconds(5),
+                    };
 
                     // Request to base address and check if various parts of the body are rendered & measure the cold startup time.
                     var response = await RetryHelper.RetryRequest(() =>
                     {
                         return httpClient.GetAsync(string.Empty);
-                    }, logger, deploymentResult.HostShutdownToken);
+                    }, logger, deploymentResult.HostShutdownToken, retryCount: 30);
 
                     var responseText = await response.Content.ReadAsStringAsync();
                     try

--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/NtlmAuthentationTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/NtlmAuthentationTest.cs
@@ -42,13 +42,17 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 {
                     var deploymentResult = deployer.Deploy();
                     var httpClientHandler = new HttpClientHandler();
-                    var httpClient = new HttpClient(httpClientHandler) { BaseAddress = new Uri(deploymentResult.ApplicationBaseUri) };
+                    var httpClient = new HttpClient(httpClientHandler)
+                    {
+                        BaseAddress = new Uri(deploymentResult.ApplicationBaseUri),
+                        Timeout = TimeSpan.FromSeconds(5),
+                    };
 
                     // Request to base address and check if various parts of the body are rendered & measure the cold startup time.
                     var response = await RetryHelper.RetryRequest(() =>
                     {
                         return httpClient.GetAsync(string.Empty);
-                    }, logger, deploymentResult.HostShutdownToken);
+                    }, logger, deploymentResult.HostShutdownToken, retryCount: 30);
 
                     var responseText = await response.Content.ReadAsStringAsync();
                     try


### PR DESCRIPTION
Under some failure conditions test requests can take 100s to timeout, and then they are retried 60 times for a total of 1.3 hours per test failure. This can cause the entire test pass to time out. Lowering this to a maximum of 5s per request, and 30 retires, for a maximum of 2.5 minutes per test failure.

@muratg 