### PR TITLE
[RC1 Tests] Publish tests with no-source to avoid signing issue.

### DIFF
--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HelloWorldTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HelloWorldTest.cs
@@ -29,18 +29,6 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
         }
 
         [ConditionalTheory]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
-        [InlineData(RuntimeFlavor.Clr, RuntimeArchitecture.x86, "http://localhost:5065/", ServerType.Kestrel)]
-        [InlineData(RuntimeFlavor.Clr, RuntimeArchitecture.x64, "http://localhost:5066/", ServerType.Kestrel)]
-        [InlineData(RuntimeFlavor.CoreClr, RuntimeArchitecture.x86, "http://localhost:5067/", ServerType.Kestrel)]
-        [InlineData(RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, "http://localhost:5068/", ServerType.Kestrel)]
-        public Task HelloWorld_IISExpress_NoSource(RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl, ServerType delegateServer)
-        {
-            return HelloWorld(ServerType.IISExpress, runtimeFlavor, architecture, applicationBaseUrl, delegateServer, noSource: true);
-        }
-
-        [ConditionalTheory]
         [SkipIfIISVariationsNotEnabled]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
@@ -52,7 +40,7 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
             return HelloWorld(ServerType.IIS, runtimeFlavor, architecture, applicationBaseUrl, delegateServer);
         }
 
-        public async Task HelloWorld(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl, ServerType delegateServer, bool noSource = false)
+        public async Task HelloWorld(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl, ServerType delegateServer)
         {
             var logger = new LoggerFactory()
                             .AddConsole()
@@ -64,7 +52,7 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
                     Command = delegateServer == ServerType.WebListener ? "weblistener" : "web",
-                    PublishWithNoSource = noSource,
+                    PublishWithNoSource = true, // Always publish with no source, otherwise it can't build and sign IISPlatformHandler
                     EnvironmentName = "HelloWorld", // Will pick the Start class named 'StartupHelloWorld',
                     ApplicationHostConfigTemplateContent = (serverType == ServerType.IISExpress) ? File.ReadAllText("Http.config") : null,
                     SiteName = "HttpTestSite", // This is configured in the Http.config

--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HttpsTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/HttpsTest.cs
@@ -38,6 +38,7 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 var deploymentParameters = new DeploymentParameters(Helpers.GetTestSitesPath(), serverType, runtimeFlavor, architecture)
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
+                    PublishWithNoSource = true, // Always publish with no source, otherwise it can't build and sign IISPlatformHandler
                     EnvironmentName = "HttpsHelloWorld", // Will pick the Start class named 'StartupHttpsHelloWorld',
                     ApplicationHostConfigTemplateContent = (serverType == ServerType.IISExpress) ? File.ReadAllText("Https.config") : null,
                     SiteName = "HttpsTestSite", // This is configured in the Https.config
@@ -106,6 +107,7 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 var deploymentParameters = new DeploymentParameters(Helpers.GetTestSitesPath(), serverType, runtimeFlavor, architecture)
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
+                    PublishWithNoSource = true, // Always publish with no source, otherwise it can't build and sign IISPlatformHandler
                     EnvironmentName = "HttpsHelloWorld", // Will pick the Start class named 'StartupHttpsHelloWorld',
                     ApplicationHostConfigTemplateContent = (serverType == ServerType.IISExpress) ? File.ReadAllText("Https.config") : null,
                     SiteName = "HttpsTestSite", // This is configured in the Https.config

--- a/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/NtlmAuthentationTest.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.FunctionalTests/NtlmAuthentationTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.AspNet.IISPlatformHandler.FunctionalTests
                 var deploymentParameters = new DeploymentParameters(Helpers.GetTestSitesPath(), serverType, runtimeFlavor, architecture)
                 {
                     ApplicationBaseUriHint = applicationBaseUrl,
+                    PublishWithNoSource = true, // Always publish with no source, otherwise it can't build and sign IISPlatformHandler
                     EnvironmentName = "NtlmAuthentication", // Will pick the Start class named 'StartupNtlmAuthentication'
                     ApplicationHostConfigTemplateContent = (serverType == ServerType.IISExpress) ? File.ReadAllText("NtlmAuthentation.config") : null,
                     SiteName = "NtlmAuthenticationTestSite", // This is configured in the NtlmAuthentication.config


### PR DESCRIPTION
@cesarbs @rynowak @davidfowl @Eilon 

This addresses some test failures introduced by the signing changes. The tests default to publishing as source and because they had a project dependency on IISPlatformHandler it was also being published as source. When the test app tried to compile IISPlatformHandler at runtime it failed because it couldn't find the key.snk singing file since it wasn't published with the sources. 
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocat
ion. ---> System.IO.FileLoadException: Could not load file or assembly 'Microsoft.AspNet.IISPlatformHandler, Version=
1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. General Exception (Exception from HRESULT:
 0x80131500) ---> Microsoft.Dnx.Compilation.CSharp.RoslynCompilationException: error CS7027: Error signing output wit
h public key from file 'C:\Users\chrross\AppData\Local\Temp\c09d62e5-0212-4eb2-a037-1b8c036b459d\approot\tools\Key.sn
k' -- Could not find a part of the path 'C:\Users\chrross\AppData\Local\Temp\c09d62e5-0212-4eb2-a037-1b8c036b459d\app
root\tools\Key.snk'.
         at Microsoft.Dnx.Compilation.CSharp.RoslynProjectReference.Load(AssemblyName assemblyName, IAssemblyLoadCont
ext loadContext)
         at Microsoft.Dnx.Compilation.CompilationEngine.LoadProject(Project project, FrameworkName targetFramework, S
tring aspect, IAssemblyLoadContext loadContext, AssemblyName assemblyName)
         at Microsoft.Dnx.Runtime.Loader.ProjectAssemblyLoader.Load(AssemblyName assemblyName, IAssemblyLoadContext l
oadContext)
         at Microsoft.Dnx.Host.LoaderContainer.Load(AssemblyName assemblyName)
         at Microsoft.Dnx.Runtime.Loader.AssemblyLoaderCache.GetOrAdd(AssemblyName name, Func`2 factory)
         at Microsoft.Dnx.Runtime.Loader.LoadContext.ResolveAssembly(Object sender, ResolveEventArgs args)
         at System.AppDomain.OnAssemblyResolveEvent(RuntimeAssembly assembly, String assemblyFullName)
         --- End of inner exception stack trace ---
         at TestSites.StartupNtlmAuthentication.Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         --- End of inner exception stack trace ---
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constru
ctor)
         at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] argume
nts)
         at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] p
arameters, CultureInfo culture)
         at Microsoft.AspNet.Hosting.Startup.ConfigureBuilder.Invoke(Object instance, IApplicationBuilder builder)
         at Microsoft.AspNet.Hosting.Internal.HostingEngine.BuildApplication()
```

We've opted to always publish --no-source in these tests.