### PR TITLE
Rename windows auth forwarder header to MS-PLATFORM-HANDLER-WINAUTHTOKEN.

### DIFF
--- a/src/Microsoft.AspNet.IISPlatformHandler/IISPlatformHandlerOptions.cs
+++ b/src/Microsoft.AspNet.IISPlatformHandler/IISPlatformHandlerOptions.cs
@@ -20,12 +20,12 @@ namespace Microsoft.AspNet.Builder
         /// If true authentication middleware will try to authenticate using platform handler windows authentication
         /// If false authentication middleware won't be added
         /// </summary>
-        public bool FlowWindowsAuthentication { get; set; } = true;
+        public bool ForwardWindowsAuthentication { get; set; } = true;
 
         /// <summary>
         /// Populates the ITLSConnectionFeature if the MS-PLATFORM-HANDLER-CLIENTCERT request header is present.
         /// </summary>
-        public bool FlowClientCertificate { get; set; } = true;
+        public bool ForwardClientCertificate { get; set; } = true;
 
         /// <summary>
         /// Additional information about the authentication type which is made available to the application.

--- a/test/Microsoft.AspNet.IISPlatformHandler.Tests/HttpPlatformHandlerMiddlewareTests.cs
+++ b/test/Microsoft.AspNet.IISPlatformHandler.Tests/HttpPlatformHandlerMiddlewareTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.IISPlatformHandler
                 {
                     app.UseIISPlatformHandler(new IISPlatformHandlerOptions
                     {
-                        FlowWindowsAuthentication = false
+                        ForwardWindowsAuthentication = false
                     });
                     app.Run(context =>
                     {


### PR DESCRIPTION
This is changing with the next version of HttpPlatformHandler so all the custome headers use the same naming scheme.

Do not merge yet or the tests will fail.
@davidfowl @pakrym 