### PR TITLE
Creating webroot if one does not exists

### DIFF
--- a/src/dotnet-publish-iis/PublishIISCommand.cs
+++ b/src/dotnet-publish-iis/PublishIISCommand.cs
@@ -30,7 +30,8 @@ namespace Microsoft.AspNetCore.Tools.PublishIIS
             var webRoot = GetWebRoot(applicationBasePath);
 
             XDocument webConfigXml = null;
-            var webConfigPath = Path.Combine(_publishFolder, webRoot, "web.config");
+            var webRootDirectory = Path.Combine(_publishFolder, webRoot);
+            var webConfigPath = Path.Combine(webRootDirectory, "web.config");
             if (File.Exists(webConfigPath))
             {
                 Reporter.Output.WriteLine($"Updating web.config at '{webConfigPath}'");
@@ -43,6 +44,12 @@ namespace Microsoft.AspNetCore.Tools.PublishIIS
             }
             else
             {
+                if (!Directory.Exists(webRootDirectory))
+                {
+                    Reporter.Output.WriteLine($"No webroot directory found. Creating '{webRootDirectory}'");
+                    Directory.CreateDirectory(webRootDirectory);
+                }
+
                 Reporter.Output.WriteLine($"No web.config found. Creating '{webConfigPath}'");
             }
 


### PR DESCRIPTION
One scenario it is useful is where the webroot does not contain any files. In this case even if the webroot is included in the "content" section dotnet publish does will not publish it.