### PR TITLE
Add the ForwardedHeadersMiddleware by default.

### DIFF
--- a/samples/IISSample/Startup.cs
+++ b/samples/IISSample/Startup.cs
@@ -1,14 +1,26 @@
 using System;
-using System.Collections;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace IISSample
 {
     public class Startup
     {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // These two middleware are registered via an IStartupFilter in UseIIS but you can configure them here.
+            services.Configure<IISOptions>(options =>
+            {
+            });
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+            });
+        }
+
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerfactory)
         {
             loggerfactory.AddConsole(LogLevel.Debug);
@@ -21,24 +33,42 @@ namespace IISSample
 
                 context.Response.ContentType = "text/plain";
                 await context.Response.WriteAsync("Hello World - " + DateTimeOffset.Now + Environment.NewLine);
-                await context.Response.WriteAsync("User - " + context.User.Identity.Name + Environment.NewLine);
+                await context.Response.WriteAsync(Environment.NewLine);
+
+                await context.Response.WriteAsync("Address:" + Environment.NewLine);
+                await context.Response.WriteAsync("Scheme: " + context.Request.Scheme + Environment.NewLine);
+                await context.Response.WriteAsync("Host: " + context.Request.Headers["Host"] + Environment.NewLine);
                 await context.Response.WriteAsync("PathBase: " + context.Request.PathBase.Value + Environment.NewLine);
                 await context.Response.WriteAsync("Path: " + context.Request.Path.Value + Environment.NewLine);
-                await context.Response.WriteAsync("ClientCert: " + context.Connection.ClientCertificate + Environment.NewLine);
+                await context.Response.WriteAsync("Query: " + context.Request.QueryString.Value + Environment.NewLine);
+                await context.Response.WriteAsync(Environment.NewLine);
 
-                await context.Response.WriteAsync(Environment.NewLine + "Headers:" + Environment.NewLine);
+                await context.Response.WriteAsync("Connection:" + Environment.NewLine);
+                await context.Response.WriteAsync("RemoteIp: " + context.Connection.RemoteIpAddress + Environment.NewLine);
+                await context.Response.WriteAsync("RemotePort: " + context.Connection.RemotePort + Environment.NewLine);
+                await context.Response.WriteAsync("LocalIp: " + context.Connection.LocalIpAddress + Environment.NewLine);
+                await context.Response.WriteAsync("LocalPort: " + context.Connection.LocalPort + Environment.NewLine);
+                await context.Response.WriteAsync("ClientCert: " + context.Connection.ClientCertificate + Environment.NewLine);
+                await context.Response.WriteAsync(Environment.NewLine);
+
+                await context.Response.WriteAsync("User: " + context.User.Identity.Name + Environment.NewLine);
+                await context.Response.WriteAsync(Environment.NewLine);
+
+                await context.Response.WriteAsync("Headers:" + Environment.NewLine);
                 foreach (var header in context.Request.Headers)
                 {
                     await context.Response.WriteAsync(header.Key + ": " + header.Value + Environment.NewLine);
                 }
+                await context.Response.WriteAsync(Environment.NewLine);
 
-                await context.Response.WriteAsync(Environment.NewLine + "Environment Variables:" + Environment.NewLine);
+                await context.Response.WriteAsync("Environment Variables:" + Environment.NewLine);
                 var vars = Environment.GetEnvironmentVariables();
-                foreach (var key in vars.Keys)
+                foreach (var key in vars.Keys.Cast<string>().OrderBy(key => key, StringComparer.OrdinalIgnoreCase))
                 {
                     var value = vars[key];
                     await context.Response.WriteAsync(key + ": " + value + Environment.NewLine);
                 }
+                await context.Response.WriteAsync(Environment.NewLine);
             });
         }
 

--- a/src/Microsoft.AspNetCore.Server.IISIntegration/IISSetupFilter.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/IISSetupFilter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration
         {
             return app =>
             {
+                app.UseForwardedHeaders();
                 app.UseMiddleware<IISMiddleware>(_pairingToken);
                 next(app);
             };

--- a/src/Microsoft.AspNetCore.Server.IISIntegration/IISWebHostExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/IISWebHostExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Server.IISIntegration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -38,6 +40,10 @@ namespace Microsoft.AspNetCore.Hosting
                 app.ConfigureServices(services =>
                 {
                     services.AddSingleton<IStartupFilter>(new IISSetupFilter(pairingToken));
+                    services.Configure<ForwardedHeadersOptions>(options =>
+                    {
+                        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                    });
                 });
             }
 

--- a/src/Microsoft.AspNetCore.Server.IISIntegration/project.json
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/project.json
@@ -15,6 +15,7 @@
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0-*",
     "Microsoft.AspNetCore.Http": "1.0.0-*",
     "Microsoft.AspNetCore.Http.Extensions": "1.0.0-*",
+    "Microsoft.AspNetCore.HttpOverrides": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Options": "1.0.0-*",
     "Microsoft.Extensions.SecurityHelper.Sources": {

--- a/test/Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests/HttpsTest.cs
+++ b/test/Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests/HttpsTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                     var responseText = await response.Content.ReadAsStringAsync();
                     try
                     {
-                        Assert.Equal("Scheme:http; Forwarded:https", responseText);
+                        Assert.Equal("Scheme:https; Original:http", responseText);
                     }
                     catch (XunitException)
                     {
@@ -138,11 +138,11 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                     {
                         if (sendClientCert)
                         {
-                            Assert.Equal("Scheme:http; Forwarded:https; has cert? True", responseText);
+                            Assert.Equal("Scheme:https; Original:http; has cert? True", responseText);
                         }
                         else
                         {
-                            Assert.Equal("Scheme:http; Forwarded:https; has cert? False", responseText);
+                            Assert.Equal("Scheme:https; Original:http; has cert? False", responseText);
                         }
                     }
                     catch (XunitException)

--- a/test/TestSites/StartupHttpsHelloWorld.cs
+++ b/test/TestSites/StartupHttpsHelloWorld.cs
@@ -17,10 +17,10 @@ namespace TestSites
             {
                 if (ctx.Request.Path.Equals(new PathString("/checkclientcert")))
                 {
-                    return ctx.Response.WriteAsync("Scheme:" + ctx.Request.Scheme + "; Forwarded:" + ctx.Request.Headers["x-forwarded-proto"]
+                    return ctx.Response.WriteAsync("Scheme:" + ctx.Request.Scheme + "; Original:" + ctx.Request.Headers["x-original-proto"]
                         + "; has cert? " + (ctx.Connection.ClientCertificate != null));
                 }
-                return ctx.Response.WriteAsync("Scheme:" + ctx.Request.Scheme + "; Forwarded:" + ctx.Request.Headers["x-forwarded-proto"]);
+                return ctx.Response.WriteAsync("Scheme:" + ctx.Request.Scheme + "; Original:" + ctx.Request.Headers["x-original-proto"]);
             });
         }
     }


### PR DESCRIPTION
#95 @DamianEdwards @davidfowl @muratg @pranavkm 

FYI: I'll need to re-order the repo dependencies for this.
It's currently:
`Hosting -> Kestrel -> IISIntegration -> ServerTests -> BasicMiddleware`
I'll need to change it to:
`Hosting -> Kestrel -> BasicMiddleware -> IISIntegration -> ServerTests`
And remove the IIS references from the BasicMiddleware samples.