### PR TITLE
Cleaning up project.json so restore works without --infer-runtimes

### DIFF
--- a/test/Microsoft.AspNetCore.Server.IISIntegration.Tools.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Server.IISIntegration.Tools.Tests/project.json
@@ -6,9 +6,9 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "portable-net451+win8",
-        "dnxcore50",
-        "netstandardapp1.5"
+        "portable-dnxcore50+net45+win8+wp8+wpa81",
+        "dotnet",
+        "portable-net45+win8"
       ],
       "dependencies": {
         "dotnet-test-xunit": "1.0.0-*",

--- a/test/TestSites/project.json
+++ b/test/TestSites/project.json
@@ -18,11 +18,15 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "portable-net451+win8",
-        "dnxcore50"
+        "portable-dnxcore50+net45+win8+wp8+wpa81",
+        "dotnet",
+        "portable-net45+win8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0-*",
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-*",
+          "type": "platform"
+        },
         "System.Net.Primitives": "4.0.11-*",
         "System.Diagnostics.Process": "4.1.0-*"
       }


### PR DESCRIPTION
cc @moozzyk 