### PR TITLE
Delay registering the url until Build

### DIFF
--- a/test/Microsoft.AspNetCore.Server.IISIntegration.Tests/IISMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Server.IISIntegration.Tests/IISMiddlewareTests.cs
@@ -73,6 +73,23 @@ namespace Microsoft.AspNetCore.Server.IISIntegration
         }
 
         [Fact]
+        public void UrlDelayRegistered()
+        {
+            var builder = new WebHostBuilder()
+                .UseSetting("TOKEN", "TestToken")
+                .UseSetting("PORT", "12345")
+                .UseSetting("APPL_PATH", "/")
+                .UseIISIntegration();
+
+            Assert.Null(builder.GetSetting(WebHostDefaults.ServerUrlsKey));
+
+            // Adds a server and calls Build()
+            var server = new TestServer(builder);
+
+            Assert.Equal("http://localhost:12345/", builder.GetSetting(WebHostDefaults.ServerUrlsKey));
+        }
+
+        [Fact]
         public async Task AddsAuthenticationHandlerByDefault()
         {
             var assertsExecuted = false;


### PR DESCRIPTION
#242 @davidfowl @JunTaoLuo @shirhatti @muratg 

Users too often break IIS by doing the following:
```
new WebHostBuilder()
 .UseKestrel()
 .UseIISIntegration()
 .UseUrls("http://mysite.com:80/");
```

This change delays registering IIS's dynamic url until Build is called so it won't be overwritten by UseUrls.