### PR TITLE
remove integration test logging

### DIFF
--- a/test/IISIntegration.FunctionalTests/HelloWorldTest.cs
+++ b/test/IISIntegration.FunctionalTests/HelloWorldTest.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
-using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;

--- a/test/IISIntegration.FunctionalTests/HttpsTest.cs
+++ b/test/IISIntegration.FunctionalTests/HttpsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,10 +9,10 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {

--- a/test/IISIntegration.FunctionalTests/NtlmAuthentationTest.cs
+++ b/test/IISIntegration.FunctionalTests/NtlmAuthentationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,13 +7,12 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
-using Xunit.Sdk;
 using Xunit.Abstractions;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 {


### PR DESCRIPTION
The `LoggedTest` helper has been moved to `Microsoft.Extensions.Logging.Testing` repo.

React to aspnet/Hosting#1039