### PR TITLE
Clear MaxRequestBodySize

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IISIntegration/IISMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/IISMiddleware.cs
@@ -76,6 +76,13 @@ namespace Microsoft.AspNetCore.Server.IISIntegration
                 return;
             }
 
+            var bodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+            if (bodySizeFeature != null)
+            {
+                // IIS already limits this, no need to do it twice.
+                bodySizeFeature.MaxRequestBodySize = null;
+            }
+
             if (_options.ForwardClientCertificate)
             {
                 var header = httpContext.Request.Headers[MSAspNetCoreClientCert];

--- a/test/IISIntegration.FunctionalTests/HelloWorldTest.cs
+++ b/test/IISIntegration.FunctionalTests/HelloWorldTest.cs
@@ -81,6 +81,10 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                         response = await deploymentResult.HttpClient.GetAsync("/Query%3FPath?query?");
                         responseText = await response.Content.ReadAsStringAsync();
                         Assert.Equal("?query?", responseText);
+
+                        response = await deploymentResult.HttpClient.GetAsync("/BodyLimit");
+                        responseText = await response.Content.ReadAsStringAsync();
+                        Assert.Equal("null", responseText);
                     }
                     catch (XunitException)
                     {

--- a/test/TestSites/StartupHelloWorld.cs
+++ b/test/TestSites/StartupHelloWorld.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 
 namespace TestSites
@@ -20,6 +21,11 @@ namespace TestSites
                 if (ctx.Request.Path.Value.StartsWith("/Query"))
                 {
                     return ctx.Response.WriteAsync(ctx.Request.QueryString.Value);
+                }
+                if (ctx.Request.Path.Value.StartsWith("/BodyLimit"))
+                {
+                    return ctx.Response.WriteAsync(
+                        ctx.Features.Get<IHttpMaxRequestBodySizeFeature>()?.MaxRequestBodySize?.ToString() ?? "null");
                 }
 
                 return ctx.Response.WriteAsync("Hello World");


### PR DESCRIPTION
IIS already limits the request body size so this avoids having to configure it both in IIS and Kestrel.