### PR TITLE
Fix auth enabled check

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Hosting
                 else
                 {
                     // Lightup a new ANCM variable that tells us if auth is enabled.
-                    foreach (var authType in iisAuth.Split(';'))
+                    foreach (var authType in iisAuth.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     {
                         if (!string.Equals(authType, "anonymous", StringComparison.OrdinalIgnoreCase))
                         {

--- a/test/TestSites/StartupHelloWorld.cs
+++ b/test/TestSites/StartupHelloWorld.cs
@@ -42,11 +42,11 @@ namespace TestSites
                     var authScheme = (await authProvider.GetAllSchemesAsync()).SingleOrDefault();
                     if (string.IsNullOrEmpty(iisAuth))
                     {
-                        await ctx.Response.WriteAsync("backcompat;" + authScheme?.Name ?? "null");
+                        await ctx.Response.WriteAsync("backcompat;" + (authScheme?.Name ?? "null"));
                     }
                     else
                     {
-                        await ctx.Response.WriteAsync("latest;" + authScheme?.Name ?? "null");
+                        await ctx.Response.WriteAsync("latest;" + (authScheme?.Name ?? "null"));
                     }
                     return;
                 }


### PR DESCRIPTION
The Win7 tests caught this because those were the only agents using the latest ANCM version. Everything else passed using the backcompat code path.