### PR TITLE
Use ipv4 when binding to ANCM port

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.AspNetCore.Hosting
                     }
                 }
 
-                var address = "http://localhost:" + port;
+                var address = "http://127.0.0.1:" + port;
                 hostBuilder.CaptureStartupErrors(true);
 
                 hostBuilder.ConfigureServices(services =>

--- a/test/Microsoft.AspNetCore.Server.IISIntegration.Tests/IISMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.Server.IISIntegration.Tests/IISMiddlewareTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration
             // Adds a server and calls Build()
             var server = new TestServer(builder);
 
-            Assert.Equal("http://localhost:12345", builder.GetSetting(WebHostDefaults.ServerUrlsKey));
+            Assert.Equal("http://127.0.0.1:12345", builder.GetSetting(WebHostDefaults.ServerUrlsKey));
             Assert.Equal("true", builder.GetSetting(WebHostDefaults.PreferHostingUrlsKey));
         }
 
@@ -270,7 +270,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration
                 });
             new TestServer(builder);
 
-            Assert.Equal("http://localhost:12345", builder.GetSetting(WebHostDefaults.ServerUrlsKey));
+            Assert.Equal("http://127.0.0.1:12345", builder.GetSetting(WebHostDefaults.ServerUrlsKey));
         }
 
         [Fact]


### PR DESCRIPTION
- Today we use localhost which binds to both the ipv4 and ipv6 addresses.
ANCM never communicates over ipv6 so it's pointless. This should also properly crash
the process if the ipv4 address fails to bind (which we've seen reports in real applications for).