### PR TITLE
Fixes bitness alignment issue for 32 bit builds

### DIFF
--- a/src/RequestHandler/inprocess/inprocessapplication.h
+++ b/src/RequestHandler/inprocess/inprocessapplication.h
@@ -3,10 +3,9 @@
 
 #pragma once
 
-typedef void(*request_handler_cb) (int error, IHttpContext* pHttpContext, void* pvCompletionContext);
-typedef REQUEST_NOTIFICATION_STATUS(*PFN_REQUEST_HANDLER) (IN_PROCESS_HANDLER* pInProcessHandler, void* pvRequestHandlerContext);
-typedef BOOL(*PFN_SHUTDOWN_HANDLER) (void* pvShutdownHandlerContext);
-typedef REQUEST_NOTIFICATION_STATUS(*PFN_MANAGED_CONTEXT_HANDLER)(void *pvManagedHttpContext, HRESULT hrCompletionStatus, DWORD cbCompletion);
+typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_REQUEST_HANDLER) (IN_PROCESS_HANDLER* pInProcessHandler, void* pvRequestHandlerContext);
+typedef BOOL( WINAPI * PFN_SHUTDOWN_HANDLER) (void* pvShutdownHandlerContext);
+typedef REQUEST_NOTIFICATION_STATUS( WINAPI * PFN_MANAGED_CONTEXT_HANDLER)(void *pvManagedHttpContext, HRESULT hrCompletionStatus, DWORD cbCompletion);
 
 class IN_PROCESS_APPLICATION : public APPLICATION
 {


### PR DESCRIPTION
For #521 
I believe this issue only occurred in Debug builds. Adding the WINAPI is the same as adding __stdcall, which I believe is needed as these functions are defined in managed.