### PR TITLE
Reorder looking for app_offline and release the lock

### DIFF
--- a/src/AspNetCore/Src/applicationmanager.cxx
+++ b/src/AspNetCore/Src/applicationmanager.cxx
@@ -124,11 +124,13 @@ APPLICATION_MANAGER::GetApplicationInfo(
         }
 
         *ppApplicationInfo = pApplicationInfo;
-        ReleaseSRWLockExclusive(&m_srwLock);
-        fExclusiveLock = FALSE;
 
         pApplicationInfo->StartMonitoringAppOffline();
         pApplicationInfo = NULL;
+
+        ReleaseSRWLockExclusive(&m_srwLock);
+        fExclusiveLock = FALSE;
+
     }
 
 Finished:


### PR DESCRIPTION
It seems that there can be a race between creating an app_offline.htm file and starting to monitor for it through the file watcher. After releasing the lock, I added a breakpoint and created an app_offline.htm file, then debug continued. The app was not taken offline, and the only way to trigger offline is to touch the app_offline file. This is especially painful on Azure websites. I switched the ordering of this to remove the issue. @pan-wang was there a good reason to have the call to app_offline outside of the lock?