### PR TITLE
Remove AspNetCoreHostingModel Property 

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IIS/Microsoft.AspNetCore.Server.IIS.targets
+++ b/src/Microsoft.AspNetCore.Server.IIS/Microsoft.AspNetCore.Server.IIS.targets
@@ -1,17 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <!--
-      This property is used by Microsoft.NET.Sdk.Web to generate a web.config file with 'hostingModel="InProcess"'.
-      When this package is referenced, it is set by default to InProcess, unless the user project contains
-      a different value for this property, or DisableInProcessHosting == true.
-
-      When AspNetCoreModuleHostingModel is empty, ANCM defaults to the reverse-proxy and out-of-process hosting model.
-
-      This property is only supported on .NET Core web applications.
-    -->
-    <AspNetCoreModuleHostingModel Condition=" '$(AspNetCoreModuleHostingModel)' == '' AND '$(DisableInProcessHosting)' != 'true' ">InProcess</AspNetCoreModuleHostingModel>
-  </PropertyGroup>
-  
   <!--
     Capability that enables Visual Studio support for hosting Asp.Net Core applications in the IIS process
   -->


### PR DESCRIPTION
We only need the the project capability; the decision to run in process/ out of process will be done either by the web.sdk (or something else to be determined).
@muratg we want to get this in preview1 as tooling needs it. 