### PR TITLE
Fix path searching for where.exe and request handler parsing

### DIFF
--- a/src/AspNetCore/Src/applicationinfo.cpp
+++ b/src/AspNetCore/Src/applicationinfo.cpp
@@ -457,7 +457,7 @@ APPLICATION_INFO::FindNativeAssemblyFromHostfxr(
     // Split on semicolons, append aspnetcorerh.dll, and check if the file exists.
     while ((intIndex = struNativeSearchPaths.IndexOf(L";", intPrevIndex)) != -1)
     {
-        if (FAILED(hr = struNativeDllLocation.Copy(struNativeSearchPaths.QueryStr(), intIndex - intPrevIndex)))
+        if (FAILED(hr = struNativeDllLocation.Copy(&struNativeSearchPaths.QueryStr()[intPrevIndex], intIndex - intPrevIndex)))
         {
             goto Finished;
         }

--- a/src/CommonLib/hostfxr_utility.cpp
+++ b/src/CommonLib/hostfxr_utility.cpp
@@ -616,18 +616,16 @@ HOSTFXR_UTILITY::FindDotnetExePath(
             {
                 goto Finished;
             }
+            // \r\n is two wchars, so add 2 here.
             prevIndex = index + 2;
 
-            if (!GetBinaryTypeW(struDotnetSubstring.QueryStr(), &dwBinaryType))
-            {
-                // TODO should we ignore this failure and continue to trying the next dotnet.exe?
-                hr = HRESULT_FROM_WIN32(GetLastError());
-                goto Finished;
-            }
-            if (fIsCurrentProcess64Bit == (dwBinaryType == SCS_64BIT_BINARY))
-            {
+            if (GetBinaryTypeW(struDotnetSubstring.QueryStr(), &dwBinaryType) &&
+                fIsCurrentProcess64Bit == (dwBinaryType == SCS_64BIT_BINARY)) {
                 // Found a valid dotnet.
-                struDotnetPath->Copy(struDotnetSubstring);
+                if (FAILED(hr = struDotnetPath->Copy(struDotnetSubstring)))
+                {
+                    goto Finished;
+                }
                 fFound = TRUE;
             }
         }

--- a/src/CommonLib/hostfxr_utility.cpp
+++ b/src/CommonLib/hostfxr_utility.cpp
@@ -612,19 +612,22 @@ HOSTFXR_UTILITY::FindDotnetExePath(
             {
                 break;
             }
-            if (FAILED(hr = struDotnetSubstring.Copy(struDotnetLocationsString.QueryStr(), index - prevIndex)))
+            if (FAILED(hr = struDotnetSubstring.Copy(&struDotnetLocationsString.QueryStr()[prevIndex], index - prevIndex)))
             {
                 goto Finished;
             }
-            prevIndex = index + 1;
+            prevIndex = index + 2;
 
-            if (GetBinaryTypeW(struDotnetSubstring.QueryStr(), &dwBinaryType) &&
-                fIsCurrentProcess64Bit == (dwBinaryType == SCS_64BIT_BINARY)) {
+            if (!GetBinaryTypeW(struDotnetSubstring.QueryStr(), &dwBinaryType))
+            {
+                // TODO should we ignore this failure and continue to trying the next dotnet.exe?
+                hr = HRESULT_FROM_WIN32(GetLastError());
+                goto Finished;
+            }
+            if (fIsCurrentProcess64Bit == (dwBinaryType == SCS_64BIT_BINARY))
+            {
                 // Found a valid dotnet.
-                if (FAILED(hr = struDotnetPath->Copy(struDotnetSubstring)))
-                {
-                    goto Finished;
-                }
+                struDotnetPath->Copy(struDotnetSubstring);
                 fFound = TRUE;
             }
         }


### PR DESCRIPTION
Two issues:
- Didn't do pointer arithmetic when iterating through paths
- Didn't add 2 when calling index of on a string of 2 characters.

This again means only the first dotnet on your path will be used (for preview1). @shirhatti should we just tell customers to use 64 bit app pools?