### PR TITLE
Delay setting content root until after build is called.

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
+++ b/src/Microsoft.AspNetCore.Server.IISIntegration/WebHostBuilderIISExtensions.cs
@@ -56,9 +56,10 @@ namespace Microsoft.AspNetCore.Hosting
                     throw exception;
                 }
 
-                hostBuilder.UseContentRoot(iisConfigData.pwzFullApplicationPath);
                 return hostBuilder.ConfigureServices(services =>
                 {
+                    // Delay setting the content root so users don't accidentally overwrite it.
+                    hostBuilder.UseContentRoot(iisConfigData.pwzFullApplicationPath);
                     services.AddSingleton<IServer, IISHttpServer>();
                     services.AddSingleton<IStartupFilter>(new IISServerSetupFilter(iisConfigData.pwzVirtualApplicationPath));
                     services.AddAuthenticationCore();


### PR DESCRIPTION
Besides adding a new main that will call WebHostBuilder.UseContentRoot(), is there any way to write a test for this?