### PR TITLE
Explore usage of std::mutex and CHandle

### DIFF
--- a/src/CommonLib/CommonLib.vcxproj
+++ b/src/CommonLib/CommonLib.vcxproj
@@ -179,6 +179,7 @@
     <ClInclude Include="hostfxr_utility.h" />
     <ClInclude Include="requesthandler.h" />
     <ClInclude Include="resources.h" />
+    <ClInclude Include="SRWLockWrapper.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="utility.h" />
   </ItemGroup>
@@ -188,6 +189,7 @@
     <ClCompile Include="fx_ver.cxx" />
     <ClCompile Include="hostfxr_utility.cpp" />
     <ClCompile Include="requesthandler.cxx" />
+    <ClCompile Include="SRWLockWrapper.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/src/CommonLib/SRWLockWrapper.cpp
+++ b/src/CommonLib/SRWLockWrapper.cpp
@@ -1,0 +1,13 @@
+#include "stdafx.h"
+#include "SRWLockWrapper.h"
+
+SRWLockWrapper::SRWLockWrapper(const SRWLOCK& lock)
+    : m_lock(lock)
+{
+    AcquireSRWLockExclusive(const_cast<SRWLOCK*>(&m_lock));
+}
+
+SRWLockWrapper::~SRWLockWrapper()
+{
+    ReleaseSRWLockExclusive(const_cast<SRWLOCK*>(&m_lock));
+}

--- a/src/CommonLib/SRWLockWrapper.h
+++ b/src/CommonLib/SRWLockWrapper.h
@@ -1,0 +1,9 @@
+#pragma once
+class SRWLockWrapper
+{
+public:
+	SRWLockWrapper(const SRWLOCK& lock);
+	~SRWLockWrapper();
+private:
+    const SRWLOCK& m_lock;
+};

--- a/src/CommonLib/application.cpp
+++ b/src/CommonLib/application.cpp
@@ -7,10 +7,10 @@ APPLICATION::APPLICATION(
     _In_ IHttpServer* pHttpServer,
     _In_ ASPNETCORE_CONFIG* pConfig) :
     m_cRefs(1),
-    m_pHttpServer(pHttpServer),
     m_pConfig(pConfig),
     m_status(APPLICATION_STATUS::UNKNOWN)
 {
+    UNREFERENCED_PARAMETER(pHttpServer);
 }
 
 APPLICATION::~APPLICATION()

--- a/src/CommonLib/application.h
+++ b/src/CommonLib/application.h
@@ -18,7 +18,7 @@ class APPLICATION
 {
 public:
     APPLICATION(
-        _In_ IHttpServer* pHttpServer, 
+        _In_ IHttpServer* pHttpServer,
         _In_ ASPNETCORE_CONFIG* pConfig);
 
     virtual
@@ -49,6 +49,5 @@ public:
 protected:
     mutable LONG            m_cRefs;
     volatile APPLICATION_STATUS m_status;
-    IHttpServer*            m_pHttpServer;
     ASPNETCORE_CONFIG*      m_pConfig;
 };

--- a/src/CommonLib/stdafx.h
+++ b/src/CommonLib/stdafx.h
@@ -21,6 +21,7 @@
 #include "..\IISLib\dbgutil.h"
 #include "..\IISLib\ahutil.h"
 #include "..\IISLib\hashfn.h"
+#include "SRWLockWrapper.h"
 #include "environmentvariablehash.h"
 #include "utility.h"
 #include "aspnetcoreconfig.h"

--- a/src/RequestHandler/inprocess/inprocessapplication.h
+++ b/src/RequestHandler/inprocess/inprocessapplication.h
@@ -110,6 +110,8 @@ private:
         VOID
     );
 
+    IHttpServer* const      m_pHttpServer;
+
     // Thread executing the .NET Core process
     HANDLE                          m_hThread;
 


### PR DESCRIPTION
This is exploratory PR which tries to explore improving our error handling/resource management patterns in native code. Main goal is to lower entry level and modernize the codebase.

Basic ideas:
1. Use RAII when possible (std::mutex, CHandle are two examples used in this PR) - provides easier, less error prone resource management and greatly simplifies logic by allowing to just `return` out of methods instead of doing goto finalization section.
2. Catch all exceptions on the border between shim and inprocess handler to prevent them from leaking up the stack.

Next possible steps:
Use exceptions for flowing HRESULTS - a lot of our methods just receive hresult check if it's failed and return it up the stack - this is exactly what exceptions are created for.

Easier to review with ?w=1 enabled:` https://github.com/aspnet/IISIntegration/pull/752?w=1`