### PR TITLE
fixing x86 build issue #780

### DIFF
--- a/src/AspNetCoreModuleV1/AspNetCore/src/serverprocess.cxx
+++ b/src/AspNetCoreModuleV1/AspNetCore/src/serverprocess.cxx
@@ -2005,7 +2005,9 @@ SERVER_PROCESS::~SERVER_PROCESS()
     InterlockedDecrement(&g_dwActiveServerProcesses);
 }
 
-VOID 
+static
+VOID
+CALLBACK
 ProcessHandleCallback(
     _In_ PVOID  pContext,
     _In_ BOOL


### PR DESCRIPTION
new compiler puts strict rules on thread callback syntax. We have to add callback keyword. key static is not required but still changes it for good coding practice.