### PR TITLE
Dispose server before checking test sink

### DIFF
--- a/test/IISIntegration.FunctionalTests/Inprocess/LoggingTests.cs
+++ b/test/IISIntegration.FunctionalTests/Inprocess/LoggingTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             Assert.Equal("Hello World", responseText);
 
-            Dispose();
+            StopServer();
 
             var folderPath = Path.Combine(deploymentResult.DeploymentResult.ContentRoot, @"logs");
 

--- a/test/IISIntegration.FunctionalTests/Inprocess/StartupExceptionTests.cs
+++ b/test/IISIntegration.FunctionalTests/Inprocess/StartupExceptionTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
+            Dispose();
+
             Assert.Contains(TestSink.Writes, context => context.Message.Contains($"Random number: {randomNumberString}"));
         }
 
@@ -47,6 +49,8 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             var response = await deploymentResult.RetryingHttpClient.GetAsync(path);
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+            Dispose();
 
             Assert.Contains(TestSink.Writes, context => context.Message.Contains(new string('a', 4096)));
         }

--- a/test/IISIntegration.FunctionalTests/Inprocess/StartupExceptionTests.cs
+++ b/test/IISIntegration.FunctionalTests/Inprocess/StartupExceptionTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            Dispose();
+            StopServer();
 
             Assert.Contains(TestSink.Writes, context => context.Message.Contains($"Random number: {randomNumberString}"));
         }
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-            Dispose();
+            StopServer();
 
             Assert.Contains(TestSink.Writes, context => context.Message.Contains(new string('a', 4096)));
         }

--- a/test/IISIntegration.FunctionalTests/Inprocess/StartupTests.cs
+++ b/test/IISIntegration.FunctionalTests/Inprocess/StartupTests.cs
@@ -126,6 +126,9 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             var deploymentResult = await DeployAsync(GetBaseDeploymentParameters("OverriddenServerWebSite"));
             var response = await deploymentResult.HttpClient.GetAsync("/");
             Assert.False(response.IsSuccessStatusCode);
+
+            Dispose();
+
             Assert.Contains(TestSink.Writes, context => context.Message.Contains("Application is running inside IIS process but is not configured to use IIS server"));
         }
 

--- a/test/IISIntegration.FunctionalTests/Inprocess/StartupTests.cs
+++ b/test/IISIntegration.FunctionalTests/Inprocess/StartupTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
             var response = await deploymentResult.HttpClient.GetAsync("/");
             Assert.False(response.IsSuccessStatusCode);
 
-            Dispose();
+            StopServer();
 
             Assert.Contains(TestSink.Writes, context => context.Message.Contains("Application is running inside IIS process but is not configured to use IIS server"));
         }

--- a/test/IISIntegration.FunctionalTests/OutOfProcess/GlobalVersionTests.cs
+++ b/test/IISIntegration.FunctionalTests/OutOfProcess/GlobalVersionTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
 
             Assert.Equal(_helloWorldResponse, responseText);
 
-            Dispose();
+            StopServer();
 
             deploymentResult = await DeployAsync(deploymentParameters);
 

--- a/test/IISIntegration.FunctionalTests/Utilities/FunctionalTestsBase.cs
+++ b/test/IISIntegration.FunctionalTests/Utilities/FunctionalTestsBase.cs
@@ -26,12 +26,13 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
 
         public override void Dispose()
         {
-            _deployer?.Dispose();
+            StopServer();
         }
 
         public void StopServer()
         {
             _deployer?.Dispose();
+            _deployer = null;
         }
     }
 }

--- a/test/IISIntegration.FunctionalTests/Utilities/FunctionalTestsBase.cs
+++ b/test/IISIntegration.FunctionalTests/Utilities/FunctionalTestsBase.cs
@@ -28,5 +28,10 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting
         {
             _deployer?.Dispose();
         }
+
+        public void StopServer()
+        {
+            _deployer?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
There has been some flakiness with checking the test sink's output, like here: https://ci3.dot.net/job/aspnet_IISIntegration/job/dev/job/windows-Configuration_Release_prtest/159/console. We may need to add a timeout here, but one mitigation we can add is disposing the iisexpress process, which should force stdout to be written.