### PR TITLE
Use less global variables in shim

### DIFF
--- a/src/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -3,6 +3,8 @@
 
 #include "globalmodule.h"
 
+extern BOOL         g_fInShutdown;
+
 ASPNET_CORE_GLOBAL_MODULE::ASPNET_CORE_GLOBAL_MODULE(
     APPLICATION_MANAGER* pApplicationManager)
 {

--- a/src/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
@@ -7,6 +7,9 @@
 #include "applicationinfo.h"
 #include "acache.h"
 #include "exceptions.h"
+
+extern BOOL         g_fInShutdown;
+
 __override
 HRESULT
 ASPNET_CORE_PROXY_MODULE_FACTORY::GetHttpModule(
@@ -83,7 +86,6 @@ ASPNET_CORE_PROXY_MODULE::OnExecuteRequestHandler(
         pApplicationManager = APPLICATION_MANAGER::GetInstance();
 
         FINISHED_IF_FAILED(pApplicationManager->GetOrCreateApplicationInfo(
-            g_pHttpServer,
             pHttpContext,
             &m_pApplicationInfo));
 

--- a/src/AspNetCoreModuleV2/AspNetCore/proxymodule.h
+++ b/src/AspNetCoreModuleV2/AspNetCore/proxymodule.h
@@ -8,8 +8,6 @@
 #include "irequesthandler.h"
 
 extern HTTP_MODULE_ID   g_pModuleId;
-extern IHttpServer     *g_pHttpServer;
-extern HMODULE          g_hAspnetCoreRH;
 
 class ASPNET_CORE_PROXY_MODULE : public CHttpModule
 {

--- a/src/AspNetCoreModuleV2/AspNetCore/stdafx.h
+++ b/src/AspNetCoreModuleV2/AspNetCore/stdafx.h
@@ -9,8 +9,8 @@
 //
 #define WIN32_LEAN_AND_MEAN
 
-#define NTDDI_VERSION 0x06010000
-#define WINVER 0x0601
+#define NTDDI_VERSION NTDDI_WIN7
+#define WINVER _WIN32_WINNT_WIN7 
 #define _WIN32_WINNT 0x0601
 
 #include <Windows.h>
@@ -19,17 +19,5 @@
 #include <ntassert.h>
 #include "stringu.h"
 #include "stringa.h"
-
-extern PVOID        g_pModuleId;
-extern BOOL         g_fAspnetcoreRHAssemblyLoaded;
-extern BOOL         g_fAspnetcoreRHLoadedError;
-extern BOOL         g_fInShutdown;
-extern BOOL         g_fEnableReferenceCountTracing;
-extern DWORD        g_dwActiveServerProcesses;
-extern HINSTANCE    g_hModule;
-extern HMODULE      g_hAspnetCoreRH;
-extern SRWLOCK      g_srwLock;
-extern PCWSTR       g_pwzAspnetcoreRequestHandlerName;
-extern HANDLE       g_hEventLog;
 
 #pragma warning( error : 4091)

--- a/src/AspNetCoreModuleV2/CommonLib/EventLog.h
+++ b/src/AspNetCoreModuleV2/CommonLib/EventLog.h
@@ -6,4 +6,6 @@
 #include "Utility.h"
 #include "resources.h"
 
+extern HANDLE       g_hEventLog;
+
 #define EVENTLOG(log, name, ...) UTILITY::LogEventF(log, ASPNETCORE_EVENT_ ## name ## _LEVEL, ASPNETCORE_EVENT_ ## name, ASPNETCORE_EVENT_ ## name ## _MSG, __VA_ARGS__)


### PR DESCRIPTION
1. Remove all of them from precompiled headers
2. Move some to instance fields
3. Move others to statics