### PR TITLE
Aquire exclusive lock when creating application info

### DIFF
--- a/samples/NativeIISSample/NativeIISSample.csproj
+++ b/samples/NativeIISSample/NativeIISSample.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <InProcessTestSite>true</InProcessTestSite>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Common.FunctionalTests/CommonStartupTests.cs
+++ b/test/Common.FunctionalTests/CommonStartupTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
+{
+    [Collection(PublishedSitesCollection.Name)]
+    public class CommonStartupTests : IISFunctionalTestBase
+    {
+        private readonly PublishedSitesFixture _fixture;
+
+        public CommonStartupTests(PublishedSitesFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public static TestMatrix TestVariants
+            => TestMatrix.ForServers(DeployerSelector.ServerType)
+                .WithTfms(Tfm.NetCoreApp22)
+                .WithAllApplicationTypes()
+                .WithAllAncmVersions()
+                .WithAllHostingModels();
+
+        [ConditionalTheory]
+        [MemberData(nameof(TestVariants))]
+        public async Task StartupStress(TestVariant variant)
+        {
+            var deploymentParameters = _fixture.GetBaseDeploymentParameters(variant, publish: true);
+
+            var deploymentResult = await DeployAsync(deploymentParameters);
+
+            await Helpers.StressLoad(deploymentResult.HttpClient, "/HelloWorld", response => {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal("Hello World", response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+            });
+        }
+    }
+}


### PR DESCRIPTION
I suspect that [this](http://aspnetci/viewLog.html?buildId=518725&buildTypeId=XPlat_Windows_Win8_Universe) failure of AppOfflineAddedAndRemovedStress is caused by insufficient locking during creation of APPLICATION_INFO that causes duplicated key error in

`| [5.377s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x800700b7 at c:\buildagent\work\33bdfc1cae7b2a38\modules\iisintegration\src\aspnetcoremodulev2\aspnetcore\applicationmanager.cpp:95 `

https://github.com/aspnet/IISIntegration/blob/1d1b2155c49427ee40639469b2632e76588efe90/src/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp#L95

I added an exclusive lock for this case and additional test cases that hammer server with requests during startup.