### PR TITLE
Fix incrementality checks for test projects

### DIFF
--- a/build/testsite.props
+++ b/build/testsite.props
@@ -37,7 +37,7 @@
 
     <AncmPath>$(AspNetCoreModuleV1ShimDll)</AncmPath>
     <AncmV2Path>$(AspNetCoreModuleV2ShimDll)</AncmV2Path>
-    <AncmInProcessRHPath>$(NativePlatform)\aspnetcorev2_inprocess.dll</AncmInProcessRHPath>
+    <AncmInProcessRHPath>aspnetcorev2_inprocess.dll</AncmInProcessRHPath>
     <DotNetPath>$(userprofile)\.dotnet\$(NativePlatform)\dotnet.exe</DotNetPath>
   </PropertyGroup>
 

--- a/samples/NativeIISSample/NativeIISSample.csproj
+++ b/samples/NativeIISSample/NativeIISSample.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <InProcessTestSite>true</InProcessTestSite>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Server.IIS/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Microsoft.AspNetCore.Server.IIS/Microsoft.AspNetCore.Server.IIS.csproj
@@ -10,6 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackNativeAssets Condition="'$(OS)' == 'Windows_NT'">true</PackNativeAssets>
     <NativeAssetsTargetFramework>netcoreapp2.2</NativeAssetsTargetFramework>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <Import Project="..\..\build\assets.props" />
@@ -23,6 +24,12 @@
 
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="$(MicrosoftAspNetCoreAuthenticationCorePackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(VCTargetsPath)' != ''">
+    <ProjectReference Include="..\AspNetCoreModuleV2\InProcessRequestHandler\InProcessRequestHandler.vcxproj" >
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -45,14 +52,6 @@
 
   <Target Name="AddRunNativeComponents" BeforeTargets="AssignTargetPaths"  Condition="$(PackNativeAssets) == 'true'">
     <ItemGroup>
-      <None Include="%(RunInProcessComponents.DllLocation)"
-               CopyToOutputDirectory="PreserveNewest"
-               Link="%(RunInProcessComponents.Platform)\%(RunInProcessComponents.NativeAsset).dll"/>
-      <None Include="%(RunInProcessComponents.PdbLocation)"
-               CopyToOutputDirectory="PreserveNewest"
-               Link="%(RunInProcessComponents.Platform)\%(RunInProcessComponents.NativeAsset).pdb"/>
-
-      <!-- Copy to platform specific and app local directory for standalone publish -->
       <None Include="%(RunInProcessComponents.DllLocation)"
                CopyToOutputDirectory="PreserveNewest"
                Link="%(RunInProcessComponents.NativeAsset).dll"/>

--- a/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
+++ b/src/Microsoft.AspNetCore.Server.IntegrationTesting.IIS/Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;iis</PackageTags>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <Import Project="..\..\build\assets.props" />
@@ -19,6 +20,18 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting" ExcludeAssets="contentfiles" PrivateAssets="None" Version="$(MicrosoftAspNetCoreServerIntegrationTestingPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="$(MicrosoftNETCoreWindowsApiSetsPackageVersion)" />
     <PackageReference Include="Microsoft.Web.Administration" Version="$(MicrosoftWebAdministrationPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(VCTargetsPath)' != ''">
+    <ProjectReference Include="..\AspNetCoreModuleV1\AspNetCore\AspNetCore.vcxproj" >
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" >
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj " >
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <Target Name="AddPackNativeComponents" BeforeTargets="_GetPackageFiles;GetSignedPackageFiles" Condition="$(PackNativeAssets) == 'true'">


### PR DESCRIPTION
When I did https://github.com/aspnet/IISIntegration/pull/1129 I've broken a scenario where native asset is being rebuilt while managed (test project/test site is not).

So I've added explicit project references from csprojes to vcxprojes that would force a rebuild. Unfortunately I had to set `DisableFastUpToDateCheck` to make them work with `<ReferenceOutputAssembly>False</ReferenceOutputAssembly>`

Additionally, I switched to always copying request handler bin local without platform subdirectory. It allows us to copy the handler only once and it would work for both build and publish scenario.