### PR TITLE
Split managed application status and IApplication status

### DIFF
--- a/src/AspNetCoreModuleV2/AspNetCore/ServerErrorApplication.h
+++ b/src/AspNetCoreModuleV2/AspNetCore/ServerErrorApplication.h
@@ -13,7 +13,6 @@ public:
         : m_HR(hr),
         PollingAppOfflineApplication(pApplication, PollingAppOfflineApplicationMode::StopWhenAdded)
     {
-        m_status = APPLICATION_STATUS::RUNNING;
     }
 
     ~ServerErrorApplication() = default;

--- a/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -54,7 +54,7 @@ APPLICATION_INFO::GetOrCreateApplication(
 )
 {
     HRESULT             hr = S_OK;
-    
+
     SRWExclusiveLock lock(m_applicationLock);
 
     auto& httpApplication = *pHttpContext->GetApplication();
@@ -72,7 +72,7 @@ APPLICATION_INFO::GetOrCreateApplication(
         else
         {
             // another thread created the application
-            FINISHED(S_OK);   
+            FINISHED(S_OK);
         }
     }
 
@@ -80,6 +80,8 @@ APPLICATION_INFO::GetOrCreateApplication(
     {
         LOG_INFO("Detected app_offline file, creating polling application");
         m_pApplication.reset(new AppOfflineApplication(httpApplication));
+        // Force status update
+        m_pApplication->QueryStatus();
     }
     else
     {
@@ -124,7 +126,7 @@ Finished:
 
     if (m_pApplication)
     {
-        pApplication = ReferenceApplication(m_pApplication.get());   
+        pApplication = ReferenceApplication(m_pApplication.get());
     }
 
     return hr;
@@ -410,7 +412,7 @@ APPLICATION_INFO::RecycleApplication()
 }
 
 
-DWORD WINAPI 
+DWORD WINAPI
 APPLICATION_INFO::DoRecycleApplication(
     LPVOID lpParam)
 {

--- a/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/applicationinfo.cpp
@@ -80,8 +80,6 @@ APPLICATION_INFO::GetOrCreateApplication(
     {
         LOG_INFO("Detected app_offline file, creating polling application");
         m_pApplication.reset(new AppOfflineApplication(httpApplication));
-        // Force status update
-        m_pApplication->QueryStatus();
     }
     else
     {

--- a/src/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
@@ -95,19 +95,11 @@ ASPNET_CORE_PROXY_MODULE::OnExecuteRequestHandler(
             // the error should already been logged to window event log for the first request
             FINISHED(E_APPLICATION_ACTIVATION_EXEC_FAILURE);
         }
-        
+
         DBG_ASSERT(pHttpContext);
 
         std::unique_ptr<IAPPLICATION, IAPPLICATION_DELETER> pApplication;
         FINISHED_IF_FAILED(m_pApplicationInfo->GetOrCreateApplication(pHttpContext, pApplication));
-
-        // We allow RECYCLED application to serve pages
-        if (pApplication->QueryStatus() != APPLICATION_STATUS::RUNNING &&
-            pApplication->QueryStatus() != APPLICATION_STATUS::STARTING &&
-            pApplication->QueryStatus() != APPLICATION_STATUS::RECYCLED)
-        {
-            FINISHED(HRESULT_FROM_WIN32(ERROR_SERVER_DISABLED));
-        }
 
         IREQUEST_HANDLER* pHandler;
         // Create RequestHandler and process the request

--- a/src/AspNetCoreModuleV2/CommonLib/AppOfflineApplication.h
+++ b/src/AspNetCoreModuleV2/CommonLib/AppOfflineApplication.h
@@ -13,6 +13,7 @@ public:
     AppOfflineApplication(IHttpApplication& pApplication)
         : PollingAppOfflineApplication(pApplication, PollingAppOfflineApplicationMode::StopWhenRemoved)
     {
+        CheckAppOffline();
     }
 
     HRESULT CreateHandler(IHttpContext* pHttpContext, IREQUEST_HANDLER** pRequestHandler) override;

--- a/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
+++ b/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
@@ -9,7 +9,12 @@
 
 APPLICATION_STATUS PollingAppOfflineApplication::QueryStatus()
 {
-    return (AppOfflineExists() == (m_mode == StopWhenRemoved)) ? APPLICATION_STATUS::RUNNING : APPLICATION_STATUS::RECYCLED;
+    if ((AppOfflineExists() != (m_mode == StopWhenRemoved)))
+    {
+        Stop(/* fServerInitiated */ false);
+    }
+
+    return APPLICATION::QueryStatus();
 }
 
 bool
@@ -29,7 +34,7 @@ PollingAppOfflineApplication::AppOfflineExists()
             m_fAppOfflineFound = is_regular_file(m_appOfflineLocation);
             if(m_fAppOfflineFound)
             {
-                LOG_IF_FAILED(OnAppOfflineFound());    
+                LOG_IF_FAILED(OnAppOfflineFound());
             }
             m_ulLastCheckTime = ulCurrentTime;
         }

--- a/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
+++ b/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
@@ -9,16 +9,12 @@
 
 APPLICATION_STATUS PollingAppOfflineApplication::QueryStatus()
 {
-    if ((AppOfflineExists() != (m_mode == StopWhenRemoved)))
-    {
-        Stop(/* fServerInitiated */ false);
-    }
-
+    CheckAppOffline();
     return APPLICATION::QueryStatus();
 }
 
-bool
-PollingAppOfflineApplication::AppOfflineExists()
+void
+PollingAppOfflineApplication::CheckAppOffline()
 {
     const auto ulCurrentTime = GetTickCount64();
     //
@@ -39,7 +35,11 @@ PollingAppOfflineApplication::AppOfflineExists()
             m_ulLastCheckTime = ulCurrentTime;
         }
     }
-    return m_fAppOfflineFound;
+
+    if (m_fAppOfflineFound != (m_mode == StopWhenRemoved))
+    {
+        Stop(/* fServerInitiated */ false);
+    }
 }
 
 

--- a/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.h
+++ b/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.h
@@ -25,7 +25,7 @@ public:
     }
 
     APPLICATION_STATUS QueryStatus() override;
-    bool AppOfflineExists();
+    void CheckAppOffline();
     virtual HRESULT OnAppOfflineFound() = 0;
     void StopInternal(bool fServerInitiated) override { UNREFERENCED_PARAMETER(fServerInitiated); }
 

--- a/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.h
+++ b/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.h
@@ -27,7 +27,7 @@ public:
     APPLICATION_STATUS QueryStatus() override;
     bool AppOfflineExists();
     virtual HRESULT OnAppOfflineFound() = 0;
-    void Stop(bool fServerInitiated) override { UNREFERENCED_PARAMETER(fServerInitiated); }
+    void StopInternal(bool fServerInitiated) override { UNREFERENCED_PARAMETER(fServerInitiated); }
 
 protected:
     std::experimental::filesystem::path m_appOfflineLocation;
@@ -36,7 +36,7 @@ protected:
 private:
     static const int c_appOfflineRefreshIntervalMS = 200;
     std::string m_strAppOfflineContent;
-    ULONGLONG m_ulLastCheckTime;    
+    ULONGLONG m_ulLastCheckTime;
     bool m_fAppOfflineFound;
     SRWLOCK m_statusLock {};
     PollingAppOfflineApplicationMode m_mode;

--- a/src/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/AspNetCoreModuleV2/CommonLib/application.h
@@ -7,11 +7,10 @@
 #include "exceptions.h"
 #include "utility.h"
 #include "ntassert.h"
-
+#include "SRWExclusiveLock.h"
 
 class APPLICATION : public IAPPLICATION
 {
-
 public:
     // Non-copyable
     APPLICATION(const APPLICATION&) = delete;
@@ -20,24 +19,38 @@ public:
     APPLICATION_STATUS
     QueryStatus() override
     {
-        return m_status;
+        return m_fStopCalled ? APPLICATION_STATUS::RECYCLED : APPLICATION_STATUS::RUNNING;
     }
 
     APPLICATION()
-        : m_cRefs(1)
+        : m_fStopCalled(false),
+          m_cRefs(1)
     {
         InitializeSRWLock(&m_stateLock);
     }
 
-    
+
     VOID
     Stop(bool fServerInitiated) override
     {
-        UNREFERENCED_PARAMETER(fServerInitiated);
+        SRWExclusiveLock stopLock(m_stateLock);
+
+        if (m_fStopCalled)
+        {
+            return;
+        }
 
         m_fStopCalled = true;
+
+        StopInternal(fServerInitiated);
     }
-    
+
+    virtual
+    VOID
+    StopInternal(bool fServerInitiated)
+    {
+        UNREFERENCED_PARAMETER(fServerInitiated);
+    }
 
     VOID
     ReferenceApplication() override
@@ -59,11 +72,9 @@ public:
     }
 
 protected:
-    volatile APPLICATION_STATUS     m_status = APPLICATION_STATUS::UNKNOWN;
     SRWLOCK m_stateLock;
     bool m_fStopCalled;
 
 private:
-
-    mutable LONG                    m_cRefs;
+    mutable LONG           m_cRefs;
 };

--- a/src/AspNetCoreModuleV2/CommonLib/application.h
+++ b/src/AspNetCoreModuleV2/CommonLib/application.h
@@ -73,7 +73,7 @@ public:
 
 protected:
     SRWLOCK m_stateLock;
-    bool m_fStopCalled;
+    bool m_fStopCalled; 
 
 private:
     mutable LONG           m_cRefs;

--- a/src/AspNetCoreModuleV2/CommonLib/iapplication.h
+++ b/src/AspNetCoreModuleV2/CommonLib/iapplication.h
@@ -8,12 +8,8 @@
 
 enum APPLICATION_STATUS
 {
-    UNKNOWN = 0,
-    STARTING,
     RUNNING,
-    SHUTDOWN,
     RECYCLED,
-    FAIL
 };
 
 struct APPLICATION_PARAMETER

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
@@ -15,9 +15,9 @@ InProcessApplicationBase::InProcessApplicationBase(
 }
 
 VOID
-InProcessApplicationBase::Stop(bool fServerInitiated)
+InProcessApplicationBase::StopInternal(bool fServerInitiated)
 {
-    AppOfflineTrackingApplication::Stop(fServerInitiated);
+    AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
     // Stop was initiated by server no need to do anything, server would stop on it's own
     if (fServerInitiated)

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.h
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.h
@@ -18,7 +18,7 @@ public:
 
     ~InProcessApplicationBase() = default;
 
-    VOID Stop(bool fServerInitiated) override;
+    VOID StopInternal(bool fServerInitiated) override;
 
 protected:
     BOOL m_fRecycleCalled;

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/ShuttingDownApplication.h
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/ShuttingDownApplication.h
@@ -32,7 +32,6 @@ public:
     ShuttingDownApplication(IHttpServer& pHttpServer, IHttpApplication& pHttpApplication)
         : InProcessApplicationBase(pHttpServer, pHttpApplication)
     {
-        m_status = APPLICATION_STATUS::RUNNING;
     }
 
     ~ShuttingDownApplication() = default;

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/StartupExceptionApplication.h
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/StartupExceptionApplication.h
@@ -16,7 +16,6 @@ public:
         : m_disableLogs(disableLogs),
         InProcessApplicationBase(pServer, pApplication)
     {
-        m_status = APPLICATION_STATUS::RUNNING;
         html500Page = std::string("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"> \
             <html xmlns=\"http://www.w3.org/1999/xhtml\"> \
             <head> \

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -40,7 +40,7 @@ IN_PROCESS_APPLICATION::IN_PROCESS_APPLICATION(
         }
     }
 
-    m_status = APPLICATION_STATUS::STARTING;
+    m_status = MANAGED_APPLICATION_STATUS::STARTING;
 }
 
 IN_PROCESS_APPLICATION::~IN_PROCESS_APPLICATION()
@@ -63,21 +63,14 @@ IN_PROCESS_APPLICATION::DoShutDown(
 
 __override
 VOID
-IN_PROCESS_APPLICATION::Stop(bool fServerInitiated)
+IN_PROCESS_APPLICATION::StopInternal(bool fServerInitiated)
 {
     UNREFERENCED_PARAMETER(fServerInitiated);
     HRESULT hr = S_OK;
     CHandle  hThread;
     DWORD    dwThreadStatus = 0;
 
-    SRWExclusiveLock stopLock(m_stateLock);
-
-    if (m_fStopCalled)
-    {
-        return;
-    }
-
-    AppOfflineTrackingApplication::Stop(fServerInitiated);
+    AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
     DWORD    dwTimeout = m_pConfig->QueryShutdownTimeLimitInMS();
 
@@ -152,16 +145,16 @@ IN_PROCESS_APPLICATION::ShutDownInternal()
     }
 
     if (m_fShutdownCalledFromNative ||
-        m_status == APPLICATION_STATUS::STARTING ||
-        m_status == APPLICATION_STATUS::FAIL)
+        m_status == MANAGED_APPLICATION_STATUS::STARTING ||
+        m_status == MANAGED_APPLICATION_STATUS::FAIL)
     {
         return;
     }
 
     {
         if (m_fShutdownCalledFromNative ||
-            m_status == APPLICATION_STATUS::STARTING ||
-            m_status == APPLICATION_STATUS::FAIL)
+            m_status == MANAGED_APPLICATION_STATUS::STARTING ||
+            m_status == MANAGED_APPLICATION_STATUS::FAIL)
         {
             return;
         }
@@ -171,7 +164,7 @@ IN_PROCESS_APPLICATION::ShutDownInternal()
         // managed. We still need to wait on main exiting no matter what. m_fShutdownCalledFromNative
         // is used for detecting redundant calls and blocking more requests to OnExecuteRequestHandler.
         m_fShutdownCalledFromNative = TRUE;
-        m_status = APPLICATION_STATUS::RECYCLED;
+        m_status = MANAGED_APPLICATION_STATUS::SHUTDOWN;
 
         if (!m_fShutdownCalledFromManaged)
         {
@@ -249,18 +242,18 @@ IN_PROCESS_APPLICATION::LoadManagedApplication
     HRESULT    hr = S_OK;
     DWORD      dwTimeout;
     DWORD      dwResult;
-    
+
     ReferenceApplication();
 
-    if (m_status != APPLICATION_STATUS::STARTING)
+    if (m_status != MANAGED_APPLICATION_STATUS::STARTING)
     {
         // Core CLR has already been loaded.
         // Cannot load more than once even there was a failure
-        if (m_status == APPLICATION_STATUS::FAIL)
+        if (m_status == MANAGED_APPLICATION_STATUS::FAIL)
         {
             hr = E_APPLICATION_ACTIVATION_EXEC_FAILURE;
         }
-        else if (m_status == APPLICATION_STATUS::SHUTDOWN)
+        else if (m_status == MANAGED_APPLICATION_STATUS::SHUTDOWN)
         {
             hr = HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IS_SCHEDULED);
         }
@@ -289,13 +282,13 @@ IN_PROCESS_APPLICATION::LoadManagedApplication
             LOG_IF_FAILED(m_pLoggerProvider->Start());
         }
 
-        if (m_status != APPLICATION_STATUS::STARTING)
+        if (m_status != MANAGED_APPLICATION_STATUS::STARTING)
         {
-            if (m_status == APPLICATION_STATUS::FAIL)
+            if (m_status == MANAGED_APPLICATION_STATUS::FAIL)
             {
                 hr = E_APPLICATION_ACTIVATION_EXEC_FAILURE;
             }
-            else if (m_status == APPLICATION_STATUS::SHUTDOWN)
+            else if (m_status == MANAGED_APPLICATION_STATUS::SHUTDOWN)
             {
                 hr = HRESULT_FROM_WIN32(ERROR_SHUTDOWN_IS_SCHEDULED);
             }
@@ -363,13 +356,13 @@ IN_PROCESS_APPLICATION::LoadManagedApplication
             goto Finished;
         }
 
-        m_status = APPLICATION_STATUS::RUNNING;
+        m_status = MANAGED_APPLICATION_STATUS::RUNNING_MANAGED;
     }
 Finished:
 
     if (FAILED(hr))
     {
-        m_status = APPLICATION_STATUS::FAIL;
+        m_status = MANAGED_APPLICATION_STATUS::FAIL;
 
         UTILITY::LogEventF(g_hEventLog,
             EVENTLOG_ERROR_TYPE,
@@ -444,7 +437,7 @@ IN_PROCESS_APPLICATION::ExecuteApplication(
     hostfxr_main_fn     pProc;
     std::unique_ptr<HOSTFXR_OPTIONS>    hostFxrOptions = NULL;
 
-    DBG_ASSERT(m_status == APPLICATION_STATUS::STARTING);
+    DBG_ASSERT(m_status == MANAGED_APPLICATION_STATUS::STARTING);
 
     pProc = s_fMainCallback;
     if (pProc == nullptr)
@@ -502,7 +495,7 @@ Finished:
     // Don't bother locking here as there will always be a race between receiving a native shutdown
     // notification and unexpected managed exit.
     //
-    m_status = APPLICATION_STATUS::SHUTDOWN;
+    m_status = MANAGED_APPLICATION_STATUS::SHUTDOWN;
     m_fShutdownCalledFromManaged = TRUE;
     FreeLibrary(hModule);
     m_pLoggerProvider->Stop();
@@ -575,12 +568,12 @@ IN_PROCESS_APPLICATION::RunDotnetApplication(DWORD argc, CONST PCWSTR* argv, hos
         {
             hr = HRESULT_FROM_WIN32(GetLastError());
         }
-        
+
         LOG_INFOF("Managed application exited with code %d", m_ProcessExitCode);
     }
     __except(GetExceptionCode() != 0)
     {
-        
+
         LOG_INFOF("Managed threw an exception %d", GetExceptionCode());
         hr = HRESULT_FROM_WIN32(GetLastError());
     }

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -70,8 +70,6 @@ IN_PROCESS_APPLICATION::StopInternal(bool fServerInitiated)
     CHandle  hThread;
     DWORD    dwThreadStatus = 0;
 
-    AppOfflineTrackingApplication::StopInternal(fServerInitiated);
-
     DWORD    dwTimeout = m_pConfig->QueryShutdownTimeLimitInMS();
 
     if (IsDebuggerPresent())
@@ -130,7 +128,7 @@ Finished:
             m_pConfig->QueryConfigPath()->QueryStr());
     }
 
-    InProcessApplicationBase::Stop(fServerInitiated);
+    InProcessApplicationBase::StopInternal(fServerInitiated);
 }
 
 VOID

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.cpp
@@ -23,7 +23,6 @@ IN_PROCESS_APPLICATION::IN_PROCESS_APPLICATION(
     APPLICATION_PARAMETER *pParameters,
     DWORD                  nParameters) :
     InProcessApplicationBase(pHttpServer, pApplication),
-    m_pHttpServer(pHttpServer),
     m_ProcessExitCode(0),
     m_fBlockCallbacksIntoManaged(FALSE),
     m_fShutdownCalledFromNative(FALSE),

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
@@ -12,15 +12,6 @@ typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_REQUEST_HANDLER) (IN_PROCESS_HA
 typedef BOOL(WINAPI * PFN_SHUTDOWN_HANDLER) (void* pvShutdownHandlerContext);
 typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_ASYNC_COMPLETION_HANDLER)(void *pvManagedHttpContext, HRESULT hrCompletionStatus, DWORD cbCompletion);
 
-enum MANAGED_APPLICATION_STATUS
-{
-    UNKNOWN = 0,
-    STARTING,
-    RUNNING_MANAGED,
-    SHUTDOWN,
-    FAIL
-};
-
 class IN_PROCESS_APPLICATION : public InProcessApplicationBase
 {
 public:
@@ -120,7 +111,14 @@ public:
 
 private:
 
-    IHttpServer &                   m_pHttpServer;
+    enum MANAGED_APPLICATION_STATUS
+    {
+        UNKNOWN = 0,
+        STARTING,
+        RUNNING_MANAGED,
+        SHUTDOWN,
+        FAIL
+    };
 
     // Thread executing the .NET Core process
     HANDLE                          m_hThread;

--- a/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
+++ b/src/AspNetCoreModuleV2/InProcessRequestHandler/inprocessapplication.h
@@ -12,6 +12,15 @@ typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_REQUEST_HANDLER) (IN_PROCESS_HA
 typedef BOOL(WINAPI * PFN_SHUTDOWN_HANDLER) (void* pvShutdownHandlerContext);
 typedef REQUEST_NOTIFICATION_STATUS(WINAPI * PFN_ASYNC_COMPLETION_HANDLER)(void *pvManagedHttpContext, HRESULT hrCompletionStatus, DWORD cbCompletion);
 
+enum MANAGED_APPLICATION_STATUS
+{
+    UNKNOWN = 0,
+    STARTING,
+    RUNNING_MANAGED,
+    SHUTDOWN,
+    FAIL
+};
+
 class IN_PROCESS_APPLICATION : public InProcessApplicationBase
 {
 public:
@@ -26,7 +35,7 @@ public:
 
     __override
     VOID
-    Stop(bool fServerInitiated) override;
+    StopInternal(bool fServerInitiated) override;
 
     VOID
     SetCallbackHandles(
@@ -138,6 +147,7 @@ private:
     volatile BOOL                   m_fShutdownCalledFromNative;
     volatile BOOL                   m_fShutdownCalledFromManaged;
     BOOL                            m_fInitialized;
+    MANAGED_APPLICATION_STATUS      m_status;
     std::unique_ptr<REQUESTHANDLER_CONFIG> m_pConfig;
 
     static IN_PROCESS_APPLICATION*  s_Application;

--- a/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
+++ b/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.cpp
@@ -12,7 +12,6 @@ OUT_OF_PROCESS_APPLICATION::OUT_OF_PROCESS_APPLICATION(
     m_fWebSocketSupported(WEBSOCKET_STATUS::WEBSOCKET_UNKNOWN),
     m_pConfig(std::move(pConfig))
 {
-    m_status = APPLICATION_STATUS::RUNNING;
     m_pProcessManager = NULL;
 }
 
@@ -62,16 +61,9 @@ OUT_OF_PROCESS_APPLICATION::GetProcess(
 
 __override
 VOID
-OUT_OF_PROCESS_APPLICATION::Stop(bool fServerInitiated)
-{   
-    SRWExclusiveLock lock(m_stateLock);
-
-    if (m_fStopCalled)
-    {
-        return;
-    }
-
-    AppOfflineTrackingApplication::Stop(fServerInitiated);
+OUT_OF_PROCESS_APPLICATION::StopInternal(bool fServerInitiated)
+{
+    AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
     if (m_pProcessManager != NULL)
     {

--- a/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.h
+++ b/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/outprocessapplication.h
@@ -32,7 +32,7 @@ public:
 
     __override
     VOID
-    Stop(bool fServerInitiated)
+    StopInternal(bool fServerInitiated)
     override;
 
     __override

--- a/src/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.cpp
+++ b/src/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.cpp
@@ -6,8 +6,6 @@
 #include "EventLog.h"
 #include "exceptions.h"
 
-extern HANDLE g_hEventLog;
-
 HRESULT AppOfflineTrackingApplication::StartMonitoringAppOffline()
 {
     LOG_INFOF("Starting app_offline monitoring in application %S", m_applicationPath.c_str());
@@ -26,11 +24,9 @@ HRESULT AppOfflineTrackingApplication::StartMonitoringAppOffline()
     return hr;
 }
 
-void AppOfflineTrackingApplication::Stop(bool fServerInitiated)
+void AppOfflineTrackingApplication::StopInternal(bool fServerInitiated)
 {
-    APPLICATION::Stop(fServerInitiated);
-
-    m_status = APPLICATION_STATUS::RECYCLED;
+    APPLICATION::StopInternal(fServerInitiated);
 
     if (m_fileWatcher)
     {

--- a/src/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.h
+++ b/src/AspNetCoreModuleV2/RequestHandlerLib/AppOfflineTrackingApplication.h
@@ -12,7 +12,8 @@ class AppOfflineTrackingApplication: public APPLICATION
 {
 public:
     AppOfflineTrackingApplication(const IHttpApplication& application)
-        : m_applicationPath(application.GetApplicationPhysicalPath()),
+        : APPLICATION(),
+        m_applicationPath(application.GetApplicationPhysicalPath()),
         m_fileWatcher(nullptr),
         m_fAppOfflineProcessed(false)
     {
@@ -23,15 +24,15 @@ public:
         if (m_fileWatcher)
         {
             m_fileWatcher->StopMonitor();
-        }   
+        }
     };
 
     HRESULT
     StartMonitoringAppOffline();
 
     VOID
-    Stop(bool fServerInitiated) override;
-    
+    StopInternal(bool fServerInitiated) override;
+
     virtual
     VOID
     OnAppOffline();

--- a/test/IIS.Tests/TestServerTest.cs
+++ b/test/IIS.Tests/TestServerTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
     {
         [ConditionalFact]
         public async Task SingleProcessTestServer_HelloWorld()
-        { while (true) {
+        {
             var helloWorld = "Hello World";
             var expectedPath = "/Path";
 
@@ -31,5 +31,5 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                     Assert.Equal(expectedPath, path);
                 }
             }
-        }}
+        }
 }

--- a/test/IIS.Tests/TestServerTest.cs
+++ b/test/IIS.Tests/TestServerTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
     {
         [ConditionalFact]
         public async Task SingleProcessTestServer_HelloWorld()
-        {
+        { while (true) {
             var helloWorld = "Hello World";
             var expectedPath = "/Path";
 
@@ -31,5 +31,5 @@ namespace Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests
                     Assert.Equal(expectedPath, path);
                 }
             }
-        }
+        }}
 }


### PR DESCRIPTION
Because of how things were implemented in the past `IAPPLICATION->QueryStatus()` got interleaved with managed application status we use in `INPROCESS_APPLICATION` this is what causes failures like:


```
Failed   Microsoft.AspNetCore.Server.IIS.FunctionalTests.AppOfflineTests.AppOfflineAddedAndRemovedStress(hostingModel: InProcess)
  Error Message:
   Status code was 500
  Expected: True
  Actual:   False
  Stack Trace:
     at Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests.Helpers.<>c__DisplayClass4_0.<<StressLoad>g__RunRequests|0>d.MoveNext() in /_/test/Common.FunctionalTests/Utilities/Helpers.cs:line 45
  --- End of stack trace from previous location where exception was thrown ---
     at Microsoft.AspNetCore.Server.IISIntegration.FunctionalTests.Helpers.StressLoad(HttpClient httpClient, String path, Action`1 action) in /_/test/Common.FunctionalTests/Utilities/Helpers.cs:line 58
     at Microsoft.AspNetCore.Server.IIS.FunctionalTests.AppOfflineTests.AppOfflineAddedAndRemovedStress(HostingModel hostingModel) in /_/test/Common.FunctionalTests/AppOfflineTests.cs:line 194
  --- End of stack trace from previous location where exception was thrown ---

   | [3.592s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Resolving hostfxr parameters for application: C:\Users\appveyor\.dotnet\x64\dotnet.exe arguments: .\InProcessWebSite.dll path: C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\
   | [3.592s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Process path C:\Users\appveyor\.dotnet\x64\dotnet.exe is dotnet, treating application as portable
   | [3.592s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Resolving absolute path to dotnet.exe from C:\Users\appveyor\.dotnet\x64\dotnet.exe
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Found dotnet.exe at C:\Users\appveyor\.dotnet\x64\dotnet.exe
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Resolving absolute path to hostfxr.dll from C:\Users\appveyor\.dotnet\x64\dotnet.exe
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] hostfxr.dll located at C:\Users\appveyor\.dotnet\x64\host\fxr\2.2.0-preview1-26618-02\hostfxr.dll
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Resolving hostfxr_main arguments application: C:\Users\appveyor\.dotnet\x64\dotnet.exe arguments: .\InProcessWebSite.dll path: C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Argument[1] = C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\InProcessWebSite.dll
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Loading request handler: C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\x64\aspnetcorev2_inprocess.dll
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Creating handler application
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] REQUESTHANDLER_CONFIG::GetConfig, set config to ModuleContext
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Resolving hostfxr_main arguments application: C:\Users\appveyor\.dotnet\x64\dotnet.exe arguments: .\InProcessWebSite.dll path: C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Argument[1] = C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\InProcessWebSite.dll
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Starting managed application
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Event Log: Application 'C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\' started the coreclr in-process successfully.
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Starting app_offline monitoring in application C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Starting file watcher thread
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Received app_offline notification in application C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Event Log: Application 'C:\Users\appveyor\AppData\Local\Temp\1\e7ce9b0c468641efb0518f6c2ce60b5f\' was recycled after detecting the app_offline file.
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Stopping file watcher thread
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Managed application exited with code 0
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2_inprocess.dll] Event Log: Application 'MACHINE/WEBROOT/APPHOST/HTTPTESTSITE20180802151425' has shutdown.
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:109 
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:125 
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:109 
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:125 
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Application went offline
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Creating handler application
   | [3.593s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:109 
   | [3.594s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Failed HRESULT returned: 0x8007053d at c:\projects\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:125 
   | [3.597s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] ASPNET_CORE_GLOBAL_MODULE::OnGlobalStopListening
   | [3.597s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] ASPNET_CORE_GLOBAL_MODULE::Terminate
   | [3.631s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [Time]: Total time taken for this test variation '3.6301795' seconds
```


APPLICATION_INFO doesn't expect statuses other than RUNNING or RECYCLED:

https://github.com/aspnet/IISIntegration/blob/05eb6a7f7c72bfec63f3c65f63a2f020fe22e705/src/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp#L105-L110

and IN_PROCESS_APPLICATION goes through more states when it shuts down.

So in this PR I've split IAPPLICATION->QueryStatus and managed application status.