### PR TITLE
Catch exceptions thrown by is_regular_file

### DIFF
--- a/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
+++ b/src/AspNetCoreModuleV2/CommonLib/PollingAppOfflineApplication.cpp
@@ -27,12 +27,20 @@ PollingAppOfflineApplication::CheckAppOffline()
         SRWExclusiveLock lock(m_statusLock);
         if (ulCurrentTime - m_ulLastCheckTime > c_appOfflineRefreshIntervalMS)
         {
-            m_fAppOfflineFound = is_regular_file(m_appOfflineLocation);
-            if(m_fAppOfflineFound)
+            try
             {
-                LOG_IF_FAILED(OnAppOfflineFound());
+                m_fAppOfflineFound = is_regular_file(m_appOfflineLocation);
+                if(m_fAppOfflineFound)
+                {
+                    LOG_IF_FAILED(OnAppOfflineFound());
+                }
+                m_ulLastCheckTime = ulCurrentTime;
             }
-            m_ulLastCheckTime = ulCurrentTime;
+            catch (...)
+            {
+                // is_regular_file might throw in very rare cases
+                OBSERVE_CAUGHT_EXCEPTION();
+            }
         }
     }
 


### PR DESCRIPTION
Looking at [this ](https://ci3.dot.net/job/aspnet_IISIntegration/job/release_2.2/job/windows-Configuration_Debug_prtest/383/consoleFull) failure of `AppOfflineAddedAndRemovedStress` it looks like `is_regular_file` is throwing:

```

15:51:29    | [1.519s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISExpressDeployer Information: iisexpress stdout: [aspnetcorev2.dll] Detected app_offline file, creating polling application
15:51:29    | [1.519s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISExpressDeployer Information: iisexpress stdout: [aspnetcorev2.dll] d:\j\workspace\windows-confi---dfc477d1\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:106 Unhandled exception: status: Access is denied.
15:51:29    | [1.519s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISExpressDeployer Information: iisexpress stdout: : "C:\Users\runner\AppData\Local\Temp\08ede57c28614af9bd5686e9a33ece79\app_offline.htm"
15:51:29    | [1.520s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISExpressDeployer Information: iisexpress stdout: Request ended: http://localhost:56673/HelloWorld with HTTP status 500.0

```

Let's catch it and swallow.