### PR TITLE
Fix incremental checks for test projects

### DIFF
--- a/build/testsite.props
+++ b/build/testsite.props
@@ -6,6 +6,7 @@
     <IISExpressAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.config</IISExpressAppHostConfig>
     <IISAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.iis.config</IISAppHostConfig>
     <PreserveCompilationContext>false</PreserveCompilationContext>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <Import Project="assets.props" />

--- a/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <TestGroupName>IIS.FunctionalTests</TestGroupName>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
+++ b/test/IISExpress.FunctionalTests/IISExpress.FunctionalTests.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
VS is not clever enough to flow incremental checks for native files transitively.