### PR TITLE
Fix is_regular_file again

### DIFF
--- a/src/AspNetCoreModuleV2/AspNetCore/AppOfflineApplication.cpp
+++ b/src/AspNetCoreModuleV2/AspNetCore/AppOfflineApplication.cpp
@@ -57,5 +57,5 @@ HRESULT AppOfflineApplication::OnAppOfflineFound()
 
 bool AppOfflineApplication::ShouldBeStarted(IHttpApplication& pApplication)
 {
-    return is_regular_file(GetAppOfflineLocation(pApplication));
+    return FileExists(GetAppOfflineLocation(pApplication));
 }

--- a/src/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.h
+++ b/src/AspNetCoreModuleV2/AspNetCore/PollingAppOfflineApplication.h
@@ -32,7 +32,7 @@ public:
 protected:
     std::filesystem::path m_appOfflineLocation;
     static std::filesystem::path GetAppOfflineLocation(IHttpApplication& pApplication);
-
+    static bool FileExists(const std::filesystem::path& path);
 private:
     static const int c_appOfflineRefreshIntervalMS = 200;
     std::string m_strAppOfflineContent;


### PR DESCRIPTION
I missed another exists check in `AppOfflineApplication::ShouldBeStarted` and it threw again.
```
 [3.439s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Application went offline
| [3.440s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] d:\b\w\33bdfc1cae7b2a38\modules\iisintegration\src\aspnetcoremodulev2\aspnetcore\proxymodule.cpp:106 Unhandled exception: status: Access is denied.
| [3.440s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: : "D:\b\t\buildTmp\5a35515066174b29af069a9a7a63bdb2\app_offline.htm"
| [3.440s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] Detected app_offline file, creating polling application
| [3.440s] Microsoft.AspNetCore.Server.IntegrationTesting.IIS.IISDeployer Information: [aspnetcorev2.dll] ASPNET_CORE_GLOBAL_MODULE::OnGlobalStopListening
```

https://github.com/aspnet/IISIntegration/issues/1216