### PR TITLE
Server 503 if server process is shutting down

### DIFF
--- a/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
+++ b/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp
@@ -344,6 +344,10 @@ Failure:
     {
         pResponse->SetStatus(400, "Bad Request", 0, hr);
     }
+    else if (hr == E_APPLICATION_EXITING)
+    {
+        pResponse->SetStatus(503, "Service Unavailable", 0, S_OK, nullptr, TRUE);
+    }
     else if (fFailedToStartKestrel && !m_pApplication->QueryConfig()->QueryDisableStartUpErrorPage())
     {
         HTTP_DATA_CHUNK   DataChunk;


### PR DESCRIPTION
Fixes: https://github.com/aspnet/IISIntegration/issues/1289

Possibly same issues in V1: https://github.com/aspnet/IISIntegration/issues/1269


When server process is shutting down `GetProcess` call would return `E_APPLICATION_EXITING` this PR makes it so we serve 503 instead of 502 in this case.

https://github.com/aspnet/IISIntegration/blob/e26231b61314b35571c99f032ae7353e72bb4056/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/forwardinghandler.cpp#L143

https://github.com/aspnet/IISIntegration/blob/e26231b61314b35571c99f032ae7353e72bb4056/src/AspNetCoreModuleV2/OutOfProcessRequestHandler/processmanager.cpp#L59-L73
