### PR TITLE
Remove Internal.Sdk reference from test projects

### DIFF
--- a/test/WebSites/Directory.Build.props
+++ b/test/WebSites/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Remove="Internal.AspNetCore.Sdk" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We don't need any Internal.SDK features in web projects.

Should help with failures like https://github.com/aspnet/IISIntegration/issues/1313