### PR TITLE
Stop calling StopCallsIntoManaged after first call

### DIFF
--- a/src/Microsoft.AspNetCore.Server.IIS/Core/IISNativeApplication.cs
+++ b/src/Microsoft.AspNetCore.Server.IIS/Core/IISNativeApplication.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 {
     internal class IISNativeApplication
     {
-        private readonly IntPtr _nativeApplication;
+        private IntPtr _nativeApplication;
 
         public IISNativeApplication(IntPtr nativeApplication)
         {
@@ -22,7 +22,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
 
         public void StopCallsIntoManaged()
         {
-            NativeMethods.HttpStopCallsIntoManaged(_nativeApplication);
+            if (_nativeApplication != IntPtr.Zero)
+            {
+                NativeMethods.HttpStopCallsIntoManaged(_nativeApplication);
+                _nativeApplication = IntPtr.Zero;
+            }
         }
 
         public void RegisterCallbacks(


### PR DESCRIPTION
[There were two test failures on shutdown on this PR. ](https://dnceng.visualstudio.com/public/_build/results?buildId=25048&view=ms.vss-test-web.test-result-details) One of them seems to be when setting `pInProcessApplication->StopCallsIntoManaged();` after managed has shut down. The actual exception seems to be in std::atomic_bool, but my guess is the native application is disposed and the IISNativeApplication finalizer is being called: https://github.com/aspnet/IISIntegration/blob/release/2.2/src/Microsoft.AspNetCore.Server.IIS/Core/IISNativeApplication.cs#L54. I otherwise can't tell what the error is.

