### PR TITLE
Code-sign Microsoft.AspNetCore.AspNetCoreModule and V2 packages

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -2,7 +2,6 @@
   <Import Project="dependencies.props" />
 
   <PropertyGroup>
-    <AssemblySigningCertName>Microsoft400</AssemblySigningCertName>
     <AncmZipOutputPath>$(BuildDir)AspNetCoreModule.zip</AncmZipOutputPath>
     <StressTestWebSiteZipOutputPath>$(BuildDir)StressTestWebSite.zip</StressTestWebSiteZipOutputPath>
   </PropertyGroup>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -35,22 +35,29 @@
   </Target>
 
   <Target Name="GetNativeArtifactsInfo">
+    <PropertyGroup>
+      <AncmPackageOutputPath>$(BuildDir)Microsoft.AspNetCore.AspNetCoreModule.$(PackageVersion).nupkg</AncmPackageOutputPath>
+      <AncmV2PackageOutputPath>$(BuildDir)Microsoft.AspNetCore.AspNetCoreModuleV2.$(PackageVersion).nupkg</AncmV2PackageOutputPath>
+    </PropertyGroup>
+
     <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
-      <ArtifactInfo Include="$(BuildDir)Microsoft.AspNetCore.AspNetCoreModule.$(PackageVersion).nupkg">
+      <ArtifactInfo Include="$(AncmPackageOutputPath)">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>Microsoft.AspNetCore.AspNetCoreModule</PackageId>
         <Version>$(PackageVersion)</Version>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
       </ArtifactInfo>
-      <FilesToExcludeFromSigning Include="$(BuildDir)Microsoft.AspNetCore.AspNetCoreModule.$(PackageVersion).nupkg" />
+      <FilesToSign Include="$(AncmPackageOutputPath)" Certificate="$(PackageSigningCertName)" />
+      <FilesToSign Include="$(RepositoryRoot)tools\installancm.ps1" Container="$(AncmPackageOutputPath)" Certificate="$(PowerShellSigningCertName)" />
 
-      <ArtifactInfo Include="$(BuildDir)Microsoft.AspNetCore.AspNetCoreModuleV2.$(PackageVersion).nupkg">
+      <ArtifactInfo Include="$(AncmV2PackageOutputPath)">
         <ArtifactType>NuGetPackage</ArtifactType>
         <PackageId>Microsoft.AspNetCore.AspNetCoreModuleV2</PackageId>
         <Version>$(PackageVersion)</Version>
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
       </ArtifactInfo>
-      <FilesToExcludeFromSigning Include="$(BuildDir)Microsoft.AspNetCore.AspNetCoreModuleV2.$(PackageVersion).nupkg" />
+      <FilesToSign Include="$(AncmV2PackageOutputPath)" Certificate="$(PackageSigningCertName)" />
+      <FilesToSign Include="$(RepositoryRoot)tools\installancm.ps1" Container="$(AncmV2PackageOutputPath)" Certificate="$(PowerShellSigningCertName)" />
 
       <ArtifactInfo Include="$(AncmZipOutputPath)">
         <ArtifactType>ZipArchive</ArtifactType>
@@ -66,7 +73,7 @@
 
       <FilesToSign Include="$(AncmZipOutputPath)" Certificate="None" IsContainer="true" />
       <FilesToExcludeFromSigning Include="$(StressTestWebSiteZipOutputPath)" />
-      <FilesToExcludeFromSigning Include="AspNetCore\ancm.mof" Container="$(BuildDir)Microsoft.AspNetCore.AspNetCoreModuleV2.$(PackageVersion).nupkg" />
+      <FilesToExcludeFromSigning Include="AspNetCore\ancm.mof" Container="$(AncmV2PackageOutputPath)" />
     </ItemGroup>
   </Target>
 

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -57,7 +57,6 @@
         <RepositoryRoot>$(RepositoryRoot)</RepositoryRoot>
       </ArtifactInfo>
       <FilesToSign Include="$(AncmV2PackageOutputPath)" Certificate="$(PackageSigningCertName)" />
-      <FilesToSign Include="$(RepositoryRoot)tools\installancm.ps1" Container="$(AncmV2PackageOutputPath)" Certificate="$(PowerShellSigningCertName)" />
 
       <ArtifactInfo Include="$(AncmZipOutputPath)">
         <ArtifactType>ZipArchive</ArtifactType>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview2-20181016.3
-commithash:17ee7986dbe75408d9e4efd94eab1003adcc3ad7
+version:2.2.0-preview2-20181019.5
+commithash:84a1c04b13bd7127728fee91989db8f2f58c8781

--- a/nuget/Microsoft.AspNetCore.AspNetCoreModuleV2.nuspec
+++ b/nuget/Microsoft.AspNetCore.AspNetCoreModuleV2.nuspec
@@ -38,7 +38,6 @@
 
     <file src="src\AspNetCoreModuleV2\AspNetCore\aspnetcore_schema_v2.xml"/>
     <file src="src\AspNetCoreModuleV2\AspNetCore\ancm.mof" />
-    <file src="tools\installancm.ps1"/>
     <file src="LICENSE.txt"/>
     <file src="$AspNetCoreModuleV2Props$" target="build\" />
   </files>


### PR DESCRIPTION
These packages are currently excluded from code signing, but they should be included, even though they are only used internally and don't go to nuget.org.